### PR TITLE
Support SMTP servers with no auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ SEND_EMAIL=false # false=write log entries but don't send
 #SMTP_HOST=localhost
 #SMTP_PORT=25
 #SMTP_REQUIRE_TLS=false
-#SMTP_AUTH_USER=user
+#SMTP_AUTH_USER=user # Leave blank or comment for no auth
 #SMTP_AUTH_PASS=pass
 
 ### SESSION STORAGE SETTINGS

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ docker compose up --build -d
 | SMTP_HOST                 | Host of the smtp server                                      | localhost       |
 | SMTP_PORT                 | Port of the smtp server                                      | 25              |
 | SMTP_REQUIRE_TLS          | Use STARTTLS                                                 | false           |
-| SMTP_AUTH_USER            | Username for the smtp server                                 | user            |
-| SMTP_AUTH_PASS            | Password for the smtp server                                 | pass            |
+| SMTP_AUTH_USER            | Username for the smtp server. Leave blank or comment for no auth |             |
+| SMTP_AUTH_PASS            | Password for the smtp server                                 |             |
 | ** SESSION STORAGE SETTINGS **    |                                                              |                 |
 | SESSIONS_SECRET           | Secret for the sessions                                      |                 |
 | SESSIONS_STORE            | Storage for the sessions (`sequelize`,`redis`)               | sequelize       |

--- a/config/app.json
+++ b/config/app.json
@@ -16,8 +16,8 @@
     "port": 25,
     "from": "email@test.com",
     "auth": {
-      "user": "user",
-      "pass": "pass"
+      "user": "",
+      "pass": ""
     }
   },
   "sessions": {

--- a/lib/email.js
+++ b/lib/email.js
@@ -41,15 +41,19 @@ const smtpTransport = require('nodemailer-smtp-transport')
 const model = require('./model/db')
 const { getCommentsForLeave } = require('./model/comment')
 
-function Email() {}
+function Email() { }
 
 const send_email = config.get('send_email')
 console.log('get_send_email: ', config.get('send_email'))
 
+let smtpConfig = config.get('smtp')
+if (!smtpConfig.auth.user) {
+  delete smtpConfig.auth
+}
 const transporter = nodemailer.createTransport(
-  smtpTransport(config.get('smtp'))
+  smtpTransport(smtpConfig)
 )
-console.log('SMTP Config:', config.get('smtp'))
+console.log('SMTP Config:', smtpConfig)
 
 // This is a little helper that ensure that data in context are in a shape
 // suitable for usage in templates
@@ -68,7 +72,7 @@ function _promise_to_unfold_context(context) {
 //  * render inner part of template
 //  * place the innerpart ingo ready to use HTML wrapper
 
-Email.prototype.promise_rendered_email_template = async function(args) {
+Email.prototype.promise_rendered_email_template = async function (args) {
   try {
     const filename = args.template_name
     const context = args.context || {}
@@ -110,18 +114,18 @@ Email.prototype.promise_rendered_email_template = async function(args) {
 // Return function that support same interface as sendMail but promisified.
 // If current configuration does not allow sending emails, it return empty function
 //
-Email.prototype.get_send_email = function() {
+Email.prototype.get_send_email = function () {
   // Check if current installation is set to send emails
   if (send_email == 'false') {
-    return function() {
+    return function () {
       console.debug('Pretend to send email: ' + JSON.stringify(arguments))
       return bluebird.resolve()
     }
   }
 
   // Send E-mail transactionnally
-  return function(data) {
-    return new Promise(function(resolve, reject) {
+  return function (data) {
+    return new Promise(function (resolve, reject) {
       transporter.sendMail(data, (err, info) => {
         if (err) {
           console.error('Error while sending mail', err)
@@ -135,7 +139,7 @@ Email.prototype.get_send_email = function() {
 
 // Send registration complete email for provided user
 //
-Email.prototype.promise_registration_email = function(args) {
+Email.prototype.promise_registration_email = function (args) {
   const self = this
   const user = args.user
   const send_mail = self.get_send_email()
@@ -157,7 +161,7 @@ Email.prototype.promise_registration_email = function(args) {
     )
 }
 
-Email.prototype.promise_add_new_user_email = function(args) {
+Email.prototype.promise_add_new_user_email = function (args) {
   const self = this
   const company = args.company
   const admin_user = args.admin_user
@@ -186,7 +190,7 @@ Email.prototype.promise_add_new_user_email = function(args) {
     )
 }
 
-Email.prototype.promise_leave_request_revoke_emails = function(args) {
+Email.prototype.promise_leave_request_revoke_emails = function (args) {
   const self = this
   const leave = args.leave
   const send_mail = self.get_send_email()
@@ -257,7 +261,7 @@ Email.prototype.promise_leave_request_revoke_emails = function(args) {
   )
 }
 
-Email.prototype.promise_leave_request_emails = function(args) {
+Email.prototype.promise_leave_request_emails = function (args) {
   const self = this
   const leave = args.leave
   const send_mail = self.get_send_email()
@@ -274,26 +278,26 @@ Email.prototype.promise_leave_request_emails = function(args) {
     comments,
     requesterAllowance
   }) => supervisor =>
-    self
-      .promise_rendered_email_template({
-        template_name: template_name_to_supervisor,
-        context: {
-          leave,
-          comments,
-          approver: supervisor,
-          requester: leave.get('user'),
-          user: supervisor,
-          requesterAllowance
-        }
-      })
-      .then(email_obj =>
-        send_mail({
-          from: config.get('smtp:from'),
-          to: supervisor.email,
-          subject: email_obj.subject,
-          html: email_obj.body
-        }).finally(() => supervisor.record_email_addressed_to_me(email_obj))
-      )
+      self
+        .promise_rendered_email_template({
+          template_name: template_name_to_supervisor,
+          context: {
+            leave,
+            comments,
+            approver: supervisor,
+            requester: leave.get('user'),
+            user: supervisor,
+            requesterAllowance
+          }
+        })
+        .then(email_obj =>
+          send_mail({
+            from: config.get('smtp:from'),
+            to: supervisor.email,
+            subject: email_obj.subject,
+            html: email_obj.body
+          }).finally(() => supervisor.record_email_addressed_to_me(email_obj))
+        )
 
   const promise_email_to_requestor = ({ comments, requesterAllowance }) =>
     self
@@ -338,7 +342,7 @@ Email.prototype.promise_leave_request_emails = function(args) {
   )
 }
 
-Email.prototype.promise_leave_request_decision_emails = function(args) {
+Email.prototype.promise_leave_request_decision_emails = function (args) {
   const self = this
   const leave = args.leave
   const action = args.action
@@ -419,7 +423,7 @@ Email.prototype.promise_leave_request_decision_emails = function(args) {
   )
 }
 
-Email.prototype.promise_forgot_password_email = function(args) {
+Email.prototype.promise_forgot_password_email = function (args) {
   const self = this
   const user = args.user
   const send_mail = self.get_send_email()
@@ -447,7 +451,7 @@ Email.prototype.promise_forgot_password_email = function(args) {
     )
 }
 
-Email.prototype.promise_reset_password_email = function(args) {
+Email.prototype.promise_reset_password_email = function (args) {
   const self = this
   const user = args.user
   const send_mail = self.get_send_email()
@@ -471,7 +475,7 @@ Email.prototype.promise_reset_password_email = function(args) {
     )
 }
 
-Email.prototype.promise_leave_request_cancel_emails = function(args) {
+Email.prototype.promise_leave_request_cancel_emails = function (args) {
   const self = this
   const leave = args.leave
   const send_mail = self.get_send_email()


### PR DESCRIPTION
- lib/email.js: remove auth from smtp transporter if SMTP_USER is blank
- updated config/app.json smtp user and pass to be blank by default
- added smtp no auth notes to .env.example and README.md