### PR TITLE
Manager/supervisor only leave types

### DIFF
--- a/lib/model/db/leave_type.js
+++ b/lib/model/db/leave_type.js
@@ -40,6 +40,12 @@ module.exports = function(sequelize, DataTypes) {
         allowNull: false,
         defaultValue: false,
         comment: 'If true, leave requests of this type will be auto-approved'
+      },
+      manager_only: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        comment: 'If true, this leave type can only be used by managers/supervisors'
       }
     },
     {

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -573,6 +573,10 @@ function get_and_validate_leave_type(args) {
     (req.body['auto_approve__' + suffix] &&
       validator.toBoolean(req.body['auto_approve__' + suffix])) ||
     false
+  const manager_only =
+    (req.body['manager_only' + suffix] &&
+      validator.toBoolean(req.body['manager_only' + suffix])) ||
+    false
 
   // If no name for leave type was provided: do nothing - treat case
   // as no need to update the leave type
@@ -611,6 +615,7 @@ function get_and_validate_leave_type(args) {
     use_personal,
     auto_approve,
     limit,
+    manager_only,
     sort_order: first_record && String(first_record) === String(suffix) ? 1 : 0
   }
 }

--- a/views/general_settings.hbs
+++ b/views/general_settings.hbs
@@ -239,6 +239,10 @@
               <input name="auto_approve__{{ this.id }}" id="auto_approve__{{ this.id }}" type="checkbox" {{#if auto_approve}}checked="checked"{{/if}} data-tom-leave-type-order="approve_{{@index}}">
               <label for="auto_approve__{{ this.id }}" class="control-label">Auto approve</label>
             </div>
+            <div>
+              <input name="manager_only__{{ this.id }}" id="manager_only__{{ this.id }}" type="checkbox" {{#if manager_only}}checked="checked"{{/if}} data-tom-leave-type-order="manager_{{@index}}">
+              <label for="manager_only__{{ this.id }}" class="control-label">Manager Only</label>
+            </div>
           </div>
           <div class="col-md-2">
             <input type="number" class="form-control" value="{{limit}}" name="limit__{{ this.id }}" data-tom-leave-type-order="limit_{{@index}}">

--- a/views/partials/add_new_leave_type_modal.hbs
+++ b/views/partials/add_new_leave_type_modal.hbs
@@ -44,6 +44,12 @@
           <p><em>If set to non-zero value determines maximum number of days of new leave type each employee could take during the year.</em></p>
         </div>
 
+        <div class="form-group">
+          <input type="checkbox" id="leave_type_manager_only_new" name="manager_only__new">&nbsp;
+          <label for="leave_type_manager_only_new" class="control-label">Admin Only</label>
+          <p><em>If checked, this leave type can only be used by managers/supervisors.</em></p>
+        </div>
+
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>

--- a/views/partials/book_leave_modal.hbs
+++ b/views/partials/book_leave_modal.hbs
@@ -26,9 +26,17 @@
             {{# is_force_to_explicitly_select_type_when_requesting_new_leave}}
               <option disabled selected value>-- select an option --</option>
             {{/ is_force_to_explicitly_select_type_when_requesting_new_leave}}
-            {{#each logged_user.company.leave_types }}
-              <option value={{this.id}} data-tom="{{this.name}}" data-tom-index={{@index}}>{{this.name}}</option>
-            {{/each}}
+            {{# if_equal logged_user.supervised_users.length 1 }}
+              {{#each logged_user.company.leave_types }}
+                {{#unless this.manager_only}}
+                  <option value={{this.id}} data-tom="{{this.name}}" data-tom-index={{@index}}>{{this.name}}</option>
+                {{/unless}}
+              {{/each}}
+            {{else}}
+              {{#each logged_user.company.leave_types }}
+                <option value={{this.id}} data-tom="{{this.name}}" data-tom-index={{@index}}>{{this.name}}</option>
+              {{/each}}
+            {{/ if_equal}}
             </select>
           </div>
 


### PR DESCRIPTION
- Employees should not be able to request certain types of leave (e.g. sick) but a manager should be able to add these leave types for employees when required
- Added new manager_only field to leave_types.js
- Added Manager Only checkbox for leave types to general_settings.hbs and add_new_leave_type_modal.hbs
- Leave type selector on book_leave_modal.hbs is now conditional bas on whether the current user manages other users, and if the leave type is manager_only or not