### PR TITLE
Allowance adjustments for all years

### DIFF
--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -575,34 +575,44 @@ module.exports = function(sequelize) {
       sorter(a.leave_type.name, b.leave_type.name)
     )
   }),
-    (this.promise_adjustment_and_carry_over_for_year = function(year) {
+    (this.promise_adjustment_and_carry_over_for_year = function(inputYear) {
       const self = this
 
-      year = year || moment.utc()
-      year = moment.utc(year).format('YYYY')
+      inputYear = inputYear || moment.utc()
+      inputYear = moment.utc(inputYear).format('YYYY')
 
-      return self
-        .getAdjustments({
-          where: { year }
-        })
-        .then(adjustment_records => {
-          // By deafault there is not adjustments
-          const result = {
+      const startYear = moment.utc(self.start_date).format('YYYY');
+
+      // Define a recursive function to look back through previous years
+      function findAdjustment(year) {
+        if (year < startYear) {
+          // If no adjustment is found by the time we reach the start year, assume 0
+          return Promise.resolve({
             adjustment: 0,
             carried_over_allowance: 0
-          }
+          });
+        }
 
+        // Try to find an adjustment for the current year
+        return self.getAdjustments({ where: { year } }).then(adjustment_records => {
+          // If an adjustment is found, stop looking back
           if (adjustment_records.length === 1) {
-            result.adjustment = adjustment_records[0].adjustment
-            result.carried_over_allowance =
-              adjustment_records[0].carried_over_allowance
+            return {
+              adjustment: adjustment_records[0].adjustment,
+              carried_over_allowance: adjustment_records[0].carried_over_allowance
+            };
           }
 
-          return Promise.resolve(result)
-        })
+          // If no adjustment is found for the current year, look back to the previous year
+          return findAdjustment(year - 1);
+        });
+      }
+
+      // Start looking back through previous years
+      return findAdjustment(inputYear);
     })
 
-  this.promise_adjustmet_for_year = function(year) {
+  this.promise_adjustment_for_year = function(year) {
     const self = this
 
     return self

--- a/lib/model/user_allowance.js
+++ b/lib/model/user_allowance.js
@@ -270,7 +270,7 @@ class UserAllowance {
     )
 
     const user = args.user
-    const year = args.year
+    let year = args.year
     let number_of_days_taken_from_allowance
     let manual_adjustment
     let carried_over_allowance
@@ -291,6 +291,30 @@ class UserAllowance {
     flow = flow.then(adjustment_and_coa => {
       manual_adjustment = adjustment_and_coa.adjustment
       carried_over_allowance = adjustment_and_coa.carried_over_allowance
+
+      // If no adjustment is found for the current year
+      if (!manual_adjustment) {
+        // Convert user.start_date to a moment object
+        const startYear = moment(user.start_date).year();
+
+        // Start looking back through previous years
+        for (let previousYear = year.year() - 1; previousYear >= startYear; previousYear--) {
+          year = moment.utc(previousYear.toString(), 'YYYY')
+          adjustment_and_coa = user.promise_adjustment_and_carry_over_for_year(year)
+          manual_adjustment = adjustment_and_coa.adjustment
+
+          // If an adjustment is found, stop looking back
+          if (manual_adjustment) {
+            break
+          }
+        }
+      }
+
+      // If no adjustment is found by the time we reach the start year, assume 0
+      if (!manual_adjustment) {
+        manual_adjustment = 0
+      }
+
       return Promise.resolve()
     })
 

--- a/lib/route/users/index.js
+++ b/lib/route/users/index.js
@@ -257,25 +257,29 @@ router.get('/edit/:user_id/absences/', (req, res) => {
 
   const dbModel = req.app.get('db_model')
 
+  const year = validator.isNumeric(req.query.year || req.body.year || '')
+    ? moment.utc(req.query.year || req.body.year, 'YYYY')
+    : req.user.company.get_today()
+
   Promise.try(() => ensure_user_id_is_integer({ req, user_id }))
     .then(() => req.user.get_company_for_user_details({ user_id }))
     .then(company => {
       const employee = company.users[0]
       return employee.reload_with_session_details()
     })
-    .then(employee => employee.reload_with_leave_details({}))
+    .then(employee => employee.reload_with_leave_details({ year }))
     .then(employee =>
       Promise.join(
         employee
-          .promise_allowance()
+          .promise_allowance({ year })
           .then(allowance_obj =>
             Promise.resolve([(user_allowance = allowance_obj), employee])
           ),
 
-        employee.promise_adjustmet_for_year(moment.utc().format('YYYY')),
+        employee.promise_adjustment_for_year(year.format('YYYY')),
 
         employee.promise_carried_over_allowance_for_year(
-          moment.utc().format('YYYY')
+          year.format('YYYY')
         ),
 
         (args, employee_adjustment, carried_over_allowance) => {
@@ -335,7 +339,11 @@ router.get('/edit/:user_id/absences/', (req, res) => {
               employee_adjustment,
               carried_over_allowance,
               user_allowance,
-              title: 'Edit user | TimeOff'
+              title: 'Edit user | TimeOff',
+              // Add the year variables here
+              previous_year: moment.utc(year).add(-1, 'year').format('YYYY'),
+              current_year: year.format('YYYY'),
+              next_year: moment.utc(year).add(1, 'year').format('YYYY')
             })
           })
       })
@@ -563,6 +571,10 @@ router.post('/edit/:user_id/', (req, res) => {
   let employee
   const model = req.app.get('db_model')
 
+  const year = validator.isNumeric(req.query.year || req.body.year || '')
+    ? moment.utc(req.query.year || req.body.year, 'YYYY')
+    : req.user.company.get_today()
+
   Promise.try(() => {
     ensure_user_id_is_integer({ req, user_id })
   })
@@ -642,7 +654,7 @@ router.post('/edit/:user_id/', (req, res) => {
         .then(() => {
           if (adjustment !== undefined) {
             return employee.promise_to_update_adjustment({
-              year: moment.utc().format('YYYY'),
+              year: year.format('YYYY'), // Use the selected year
               adjustment
             })
           }
@@ -655,7 +667,7 @@ router.post('/edit/:user_id/', (req, res) => {
             'Details for ' + employee.full_name() + ' were updated'
           )
           return res.redirect_with_session(
-            req.body.back_to_absences ? './absences/' : '.'
+            req.body.back_to_absences ? './absences/?year=' + year.format('YYYY') : '.?year=' + year.format('YYYY')
           )
         })
     })

--- a/views/partials/user_details/absences.hbs
+++ b/views/partials/user_details/absences.hbs
@@ -11,8 +11,21 @@
   <input type="hidden" name="admin" value="{{#if employee.admin}}1{{else}}0{{/if}}">
   <input type="hidden" name="start_date" value="{{as_date employee.start_date}}">
   <input type="hidden" name="end_date" value="{{as_date employee.end_date}}">
+  <input type="hidden" name="year" value="{{current_year}}">
 
   {{> user_details/breadcrumb employee=employee }}
+
+  <div class="row">
+    <div class="col-xs-2">
+      <a class="btn btn-default" href="/users/edit/{{employee.id}}/absences/?year={{previous_year}}"><span aria-hidden="true" class="fa fa-chevron-left"></span> {{previous_year}} </a>
+    </div>
+    <div class="col-xs-8 calendar-section-caption">
+      <h3>{{current_year}}</h3>
+    </div>
+    <div class="col-xs-2">
+      <a class="btn btn-default pull-right" href="/users/edit/{{employee.id}}/absences/?year={{next_year}}">{{next_year}} <span aria-hidden="true" class="fa fa-chevron-right"></span></a>
+    </div>
+  </div>
 
   <div class="form-group">
     <label class="control-label">Overview</label>
@@ -20,7 +33,7 @@
       <div
         class="progress-bar progress-bar-success"
         style="width: {{ leave_statistics.used_so_far_percent }}%"
-        data-content="{{# with employee }}{{this.full_name }}{{/with}} in current year used {{ leave_statistics.used_so_far }} days from allowance"
+        data-content="{{# with employee }}{{this.full_name }}{{/with}} in {{current_year}} used {{ leave_statistics.used_so_far }} days from allowance"
         data-placement="top"
         data-toggle="popover"
         data-trigger="focus hover"
@@ -35,13 +48,13 @@
         data-toggle="popover"
         data-trigger="focus hover"
       >
-        {{ leave_statistics.remaining  }} days remaining in current year
+        {{ leave_statistics.remaining  }} days remaining in {{current_year}}
       </div>
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label">Days available for {{ employee.name }} to take this year</label>
+    <label class="control-label">Days available for {{ employee.name }} to take in {{current_year}}</label>
     <p>{{ user_allowance.number_of_days_available_in_allowance }} out of {{ user_allowance.total_number_of_days_in_allowance }} in allowance</p>
     <input id="days_remaining_inp" type="hidden" value="{{ user_allowance.number_of_days_available_in_allowance }} out of {{ user_allowance.total_number_of_days_in_allowance }}">
   </div>
@@ -88,15 +101,15 @@
   </div>
 
   <div class="form-group">
-    <label for="adjustment_inp" class="control-label">Allowance adjustment in current year</label>
+    <label for="adjustment_inp" class="control-label">Allowance adjustment in {{current_year}}</label>
     <div class="input-group col-md-4">
       <input class="form-control" id="adjustment_inp" type="number" step="0.5" name="adjustment" value="{{#if employee_adjustment }}{{employee_adjustment}}{{else}}0{{/if}}" aria-describedby="adjustment_help">
       <span class="input-group-addon">working days</span>
     </div>
     <div id="adjustment_help" class="help-block">
-      <div>Tune allowance for this user in current year.</div>
-      <div>Could be negative as well.</div>
-      <div>The value is valid during current year. Next year it needs to be re-confirmed.</div>
+      <div>Tune allowance for this user in {{current_year}}.</div>
+      <div>Can be negative as well.</div>
+      <div>If no value is set for this year, the last adjustment from previous years will be used</div>
     </div>
   </div>
 


### PR DESCRIPTION
- no longer required to update adjustments for each year
- if no adjustment exists for the current year, will search back through previous years to find the last adjustment
- adjustments can still be made for individual years
- year switcher added to absences page