### PR TITLE
Show all menus in mobile view

### DIFF
--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -23,7 +23,7 @@
           <li><a href="/calendar/teamview/">Team View</a></li>
           {{/if}}
           {{#if logged_user.admin}}
-          <li class="hidden-xs"><a href="/users/">Employees</a></li>
+          <li><a href="/users/">Employees</a></li>
           {{/if}}
           <li class="navbar-form navbar-left">
             <div class="form-group">
@@ -65,7 +65,7 @@
             </ul>
           </li>
           {{#if logged_user.admin }}
-          <li class="dropdown hidden-xs">
+          <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span
                 class="fa fa-gears"></span> <span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
@@ -84,7 +84,7 @@
           {{/if}}
           <li class="visible-xs-block"><a href="/requests/">Requests</a></li>
           <li class="visible-xs-block"><a href="/logout/">Logout</a></li>
-          <li class="dropdown hidden-xs">
+          <li class="dropdown">
             <a id="me_menu" href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
               aria-expanded="false">Me
               <span class="caret"></span></a>


### PR DESCRIPTION
Some menus are hidden in mobile view.
With the requirement to manage on the move, these should always be visible. Removed hidden class